### PR TITLE
Multiple raven forms on one page can have unique success/error states.

### DIFF
--- a/add-ons/raven/hooks.raven.php
+++ b/add-ons/raven/hooks.raven.php
@@ -171,6 +171,19 @@ class Hooks_raven extends Hooks {
       'submission' => $submission,
       'config' => $config)
     );
+
+    /*
+    |--------------------------------------------------------------------------
+    | Form Identifier
+    |--------------------------------------------------------------------------
+    |
+    | In the event of multiple forms on a page, we'll be able to determine
+    | which one was the one that had been triggered.
+    |
+    */
+
+    $this->flash->set('form_id', $hidden['raven']);
+
     /*
     |--------------------------------------------------------------------------
     | Finalize & determine action

--- a/add-ons/raven/pi.raven.php
+++ b/add-ons/raven/pi.raven.php
@@ -54,6 +54,8 @@ class Plugin_raven extends Plugin {
 		|
 		*/
 
+		$form_id = $this->fetchParam('id', true);
+
 		$attributes_string = '';
 
 		if ($attr = $this->fetchParam('attr', false)) {
@@ -64,7 +66,7 @@ class Plugin_raven extends Plugin {
 		}
 
 		$html  = "<form method='post' {$attributes_string}>\n";
-		$html .= "<input type='hidden' name='hidden[raven]' value='true' />\n";
+		$html .= "<input type='hidden' name='hidden[raven]' value='{$form_id}' />\n";
 		$html .= "<input type='hidden' name='hidden[formset]' value='{$formset}' />\n";
 		$html .= "<input type='hidden' name='hidden[return]' value='{$return}' />\n";
 		$html .= "<input type='hidden' name='hidden[error_return]' value='{$error_return}' />\n";
@@ -108,6 +110,10 @@ class Plugin_raven extends Plugin {
 	**/
 	public function success()
 	{
+		if ( ! $this->isActiveForm()) {
+			return false;
+		}
+
 		return $this->flash->get('success');  
 	}
 
@@ -120,6 +126,10 @@ class Plugin_raven extends Plugin {
 	**/
 	public function errors()
 	{
+		if ( ! $this->isActiveForm()) {
+			return false;
+		}
+
 		if ($errors = $this->flash->get('errors')) {
 			return Parse::template($this->content, $errors);
 		}
@@ -129,6 +139,10 @@ class Plugin_raven extends Plugin {
 
 	public function has_errors()
 	{
+		if ( ! $this->isActiveForm()) {
+			return false;
+		}
+
 		if ($errors = $this->flash->get('errors')) {
 			if (is_array(array_get($errors, 'invalid')) || is_array(array_get($errors, 'missing'))) {
 				return true;
@@ -136,5 +150,19 @@ class Plugin_raven extends Plugin {
 		}
 
 		return false;
+	}
+
+
+	/**
+	* Returns true or false based on whether the form was the one submitted
+	*
+	* If using multiple forms on one page, `raven` tags should have a
+	* common `id` parameter between each set.
+	*
+	* @return bool
+	**/
+	private function isActiveForm()
+	{
+		return $this->flash->get('form_id') == $this->fetchParam('id', 1);
 	}
 }


### PR DESCRIPTION
This PR addresses this issue: http://support.statamic.com/discussions/raven/31-two-forms-on-single-page

If you have multiple Raven forms / success or error conditionals on a single page - submitting one of them will trigger _all_ conditionals.

With this PR, if you want to have multiple forms on a page, you can give your `raven` tags an `id` parameter.

```
<h1>Form 1:</h1>

{{ if {raven:has_errors} }}
  Errors!
  {{ raven:errors }}...{{ /raven:errors }}
{{ endif }}

{{ if {raven:success} }}
  Success!
{{ endif }}

{{ raven:form }}
  <input type="submit" />
{{ /raven:form }}

<hr />

<h1>Form 2:</h1>

{{ if {raven:has_errors id="numero_dos"} }}
  Errors!
  {{ raven:errors id="numero_dos" }}...{{ /raven:errors }}
{{ endif }}

{{ if {raven:success id="numero_dos"} }}
  Success!
{{ endif }}

{{ raven:form id="numero_dos" }}
  <input type="submit" />
{{ /raven:form }}
```

In this example, you can just slap `id`'s on the second set. You could put `id`'s on the first, or both sets if you want.

I don't know if `id` is the right parameter to use. It's a PR after all, so hey, have at it.
