### PR TITLE
slugify filenames on upload

### DIFF
--- a/add-ons/raven/hooks.raven.php
+++ b/add-ons/raven/hooks.raven.php
@@ -314,6 +314,8 @@ class Hooks_raven extends Hooks {
 
 			foreach ($files as $name => $file) {
 				if ($file['success']) {
+					$file['name'] = Slug::make($file['name'], array('maintain_case' => true));
+					
 					$submission[$name] = File::upload($file, $upload_destination);
 				}
 			}


### PR DESCRIPTION
Spaces in filenames were biting me, so I'm slugifying them with case maintained. Not sure of any reason **not** to do this.
